### PR TITLE
Make Hyperproof OAuth scopes optional.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/hypersync-sdk",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Hypersync SDK",
   "repository": {
     "type": "git",

--- a/src/common/hyperproofTokens.ts
+++ b/src/common/hyperproofTokens.ts
@@ -102,7 +102,7 @@ export const getHyperproofAuthConfig = (
     ...baseConfig,
     hyperproofClientId: process.env.hyperproof_oauth_client_id,
     hyperproofRedirectUrl: getHyperproofRedirectUrl(fusebitContext),
-    hyperproofScopes: process.env.hyperproof_oauth_scope!.split(' ')
+    hyperproofScopes: process.env.hyperproof_oauth_scope?.split(' ')
   } as IAuthorizationConfig;
 };
 


### PR DESCRIPTION
This supports issue #3.