### PR TITLE
Fix custom app logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/hypersync-sdk",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Hypersync SDK",
   "repository": {
     "type": "git",

--- a/src/common/sharedConnector.ts
+++ b/src/common/sharedConnector.ts
@@ -150,11 +150,24 @@ export function createConnector(superclass: typeof OAuthConnector) {
           setHyperproofClientSecret(clientSecret);
         }
 
+        // Split up the URL and look for the orgId and/or userId params.
+        let orgId: string | undefined;
+        let userId: string | undefined;
+        const parts = req.url.split('/');
+        for (let i = 0; i < parts.length - 1; i++) {
+          if (parts[i] === 'organizations') {
+            orgId = parts[i + 1];
+          }
+          if (parts[i] === 'users') {
+            userId = parts[i + 1];
+          }
+        }
+
         Logger.init(
           {
             [LoggerContextKey.IntegrationType]: this.integrationType,
-            [LoggerContextKey.OrgId]: req.params.orgId,
-            [LoggerContextKey.UserId]: req.params.userId
+            [LoggerContextKey.OrgId]: orgId,
+            [LoggerContextKey.UserId]: userId
           },
           subscriptionKey ?? process.env.hyperproof_api_subscription_key
         );


### PR DESCRIPTION
We weren't properly retrieving the org ID or user ID from the request in the `app.use` that I created a while back.  Not sure why I thought it worked the way that it did.  Because of this bug, there is no org ID or user ID associated with log events posted from integrations to the front end.

This supports issue #3.