### PR TITLE
Add support for declarative paging [S]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/hypersync-sdk",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Hypersync SDK",
   "repository": {
     "type": "git",

--- a/src/hypersync/DeclarativeProofProvider.ts
+++ b/src/hypersync/DeclarativeProofProvider.ts
@@ -1,8 +1,7 @@
-import { IHyperproofUser, Logger } from '../common';
 import fs from 'fs';
 import path from 'path';
+import { IHyperproofUser, Logger } from '../common';
 import { ID_ALL, ID_ANY, ID_NONE, StringMap } from './common';
-import { ICriteriaPage, IProofCriterionRef } from './ICriteriaProvider';
 import { DeclarativeCriteriaProvider } from './DeclarativeCriteriaProvider';
 import {
   DataSetResultStatus,
@@ -13,12 +12,13 @@ import {
   HypersyncPeriod,
   HypersyncTemplate
 } from './enums';
+import { ICriteriaPage, IProofCriterionRef } from './ICriteriaProvider';
+import { DataValueMap, IDataSource } from './IDataSource';
 import { DataObject, HypersyncCriteria, IHypersync } from './models';
+import { IProofFile, ProofProviderBase } from './ProofProviderBase';
+import { IGetProofDataResponse, SyncMetadata } from './Sync';
 import { dateToLocalizedString } from './time';
 import { resolveTokens, TokenContext } from './tokens';
-import { IProofFile, ProofProviderBase } from './ProofProviderBase';
-import { DataValueMap, IDataSource } from './IDataSource';
-import { IGetProofDataResponse, SyncMetadata } from './Sync';
 
 interface ILookup {
   name: string;
@@ -162,7 +162,7 @@ export class DeclarativeProofProvider extends ProofProviderBase {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     syncStartDate: Date,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    page?: number,
+    page?: string,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     metadata?: SyncMetadata
   ): Promise<IProofFile[] | IGetProofDataResponse> {
@@ -186,6 +186,7 @@ export class DeclarativeProofProvider extends ProofProviderBase {
     const response = await this.dataSource.getData(
       proofSpec.dataSet,
       params,
+      page,
       metadata
     );
 
@@ -237,45 +238,49 @@ export class DeclarativeProofProvider extends ProofProviderBase {
     // Proof is always stored as an array.
     const proof = Array.isArray(data) ? data : [data];
 
-    return [
-      {
-        filename: settings.name,
-        contents: {
-          type: process.env.integration_type!,
-          title: resolveTokens(proofSpec.title, tokenContext),
-          subtitle: resolveTokens(proofSpec.subtitle, tokenContext),
-          source: apiUrl,
-          webPageUrl: resolveTokens(proofSpec.webPageUrl, tokenContext),
-          orientation: proofSpec.orientation,
-          userTimeZone: hyperproofUser.timeZone,
-          criteria,
-          proofFormat: settings.proofFormat,
-          template: HypersyncTemplate.UNIVERSAL,
-          layout: {
-            format: proofSpec.format,
-            noResultsMessage:
-              proof.length > 0 || !proofSpec.noResultsMessage
-                ? ''
-                : resolveTokens(proofSpec.noResultsMessage, tokenContext),
-            fields: proofSpec.fields.map(f => ({
-              property: f.property,
-              label: resolveTokens(f.label, tokenContext),
-              width: f.width,
-              type: f.type === HypersyncFieldType.TEXT ? undefined : f.type
-            }))
-          },
-          proof,
-          authorizedUser,
-          collector: this.connectorName,
-          collectedOn: dateToLocalizedString(
-            syncStartDate,
-            hyperproofUser.timeZone,
-            hyperproofUser.language,
-            hyperproofUser.locale
-          )!
+    return {
+      nextPage: response.nextPage,
+      combine: true,
+      data: [
+        {
+          filename: settings.name,
+          contents: {
+            type: process.env.integration_type!,
+            title: resolveTokens(proofSpec.title, tokenContext),
+            subtitle: resolveTokens(proofSpec.subtitle, tokenContext),
+            source: apiUrl,
+            webPageUrl: resolveTokens(proofSpec.webPageUrl, tokenContext),
+            orientation: proofSpec.orientation,
+            userTimeZone: hyperproofUser.timeZone,
+            criteria,
+            proofFormat: settings.proofFormat,
+            template: HypersyncTemplate.UNIVERSAL,
+            layout: {
+              format: proofSpec.format,
+              noResultsMessage:
+                proof.length > 0 || !proofSpec.noResultsMessage
+                  ? ''
+                  : resolveTokens(proofSpec.noResultsMessage, tokenContext),
+              fields: proofSpec.fields.map(f => ({
+                property: f.property,
+                label: resolveTokens(f.label, tokenContext),
+                width: f.width,
+                type: f.type === HypersyncFieldType.TEXT ? undefined : f.type
+              }))
+            },
+            proof,
+            authorizedUser,
+            collector: this.connectorName,
+            collectedOn: dateToLocalizedString(
+              syncStartDate,
+              hyperproofUser.timeZone,
+              hyperproofUser.language,
+              hyperproofUser.locale
+            )!
+          }
         }
-      }
-    ];
+      ]
+    };
   }
 
   /**

--- a/src/hypersync/DeclarativeProofProvider.ts
+++ b/src/hypersync/DeclarativeProofProvider.ts
@@ -239,8 +239,6 @@ export class DeclarativeProofProvider extends ProofProviderBase {
     const proof = Array.isArray(data) ? data : [data];
 
     return {
-      nextPage: response.nextPage,
-      combine: true,
       data: [
         {
           filename: settings.name,
@@ -279,7 +277,9 @@ export class DeclarativeProofProvider extends ProofProviderBase {
             )!
           }
         }
-      ]
+      ],
+      nextPage: response.nextPage,
+      combine: true
     };
   }
 

--- a/src/hypersync/HypersyncApp.ts
+++ b/src/hypersync/HypersyncApp.ts
@@ -1,10 +1,16 @@
 import { FusebitContext } from '@fusebit/add-on-sdk';
 import {
   createOAuthConnector,
+  OAuthConnector,
   OAuthTokenResponse,
-  UserContext,
-  OAuthConnector
+  UserContext
 } from '@fusebit/oauth-connector';
+import fs from 'fs';
+import createHttpError from 'http-errors';
+import { StatusCodes } from 'http-status-codes';
+import path from 'path';
+import { ParsedQs } from 'qs';
+import Superagent from 'superagent';
 import {
   AuthorizationType,
   CustomAuthCredentials,
@@ -18,12 +24,6 @@ import {
   Logger,
   ObjectType
 } from '../common';
-import fs from 'fs';
-import createHttpError from 'http-errors';
-import { StatusCodes } from 'http-status-codes';
-import path from 'path';
-import { ParsedQs } from 'qs';
-import Superagent from 'superagent';
 import { formatHypersyncError, StringMap } from './common';
 import { HypersyncPeriod } from './enums';
 import {
@@ -192,7 +192,7 @@ class HypersyncAppConnector extends createHypersync(OAuthConnector) {
     hypersync: IHypersync,
     syncStartDate: string,
     hyperproofUser: IHyperproofUser,
-    page?: number,
+    page?: string,
     metadata?: SyncMetadata
   ) {
     const vendorUserId = hypersync.settings.vendorUserId;
@@ -596,7 +596,7 @@ export class HypersyncApp<TUserProfile = object> {
     hyperproofUser: IHyperproofUser,
     userProfile: TUserProfile,
     syncStartDate: string,
-    page?: number,
+    page?: string,
     metadata?: SyncMetadata
   ): Promise<IProofFile[] | IGetProofDataResponse> {
     const factory = await this.getProofProviderFactory();

--- a/src/hypersync/IDataSource.ts
+++ b/src/hypersync/IDataSource.ts
@@ -1,5 +1,5 @@
 import { DataSetResultStatus } from './enums';
-import { DataValue, DataObject } from './models';
+import { DataObject, DataValue } from './models';
 import { SyncMetadata } from './Sync';
 import { TokenContext } from './tokens';
 
@@ -12,6 +12,7 @@ export interface IDataSetResultComplete<TData = DataObject> {
   data: TData;
   apiUrl: string;
   context?: TokenContext;
+  nextPage?: string;
 }
 
 export interface IDataSetResultPending {
@@ -39,6 +40,7 @@ export interface IDataSource {
   getData<TData = DataObject>(
     dataSetName: string,
     params?: DataValueMap,
+    page?: string,
     metadata?: SyncMetadata
   ): Promise<DataSetResult<TData>>;
 }

--- a/src/hypersync/IDataSource.ts
+++ b/src/hypersync/IDataSource.ts
@@ -11,8 +11,8 @@ export interface IDataSetResultComplete<TData = DataObject> {
   status: DataSetResultStatus.Complete;
   data: TData;
   apiUrl: string;
-  context?: TokenContext;
   nextPage?: string;
+  context?: TokenContext;
 }
 
 export interface IDataSetResultPending {
@@ -35,7 +35,11 @@ export interface IDataSource {
    *
    * @param {string} dataSetName Name of the data set to retrieve.
    * @param {object} params Parameter values to be used when retrieving data. Optional.
-   * @param {object} metadata Metadata from previous sync run if requeued. Optional.
+   * @param {string} page The page value to continue fetching data from a previous sync.
+   *  This has the same value as the nextPage property returned from the previous sync
+   *  if the status was Complete. Optional.
+   * @param {object} metadata Metadata from previous sync run if requeued. Only returned
+   *  from the previous sync if the status was Pending. Optional.
    */
   getData<TData = DataObject>(
     dataSetName: string,

--- a/src/hypersync/ProofProviderBase.ts
+++ b/src/hypersync/ProofProviderBase.ts
@@ -171,7 +171,7 @@ export class ProofProviderBase<T = any> {
     hyperproofUser: IHyperproofUser,
     authorizedUser: string,
     syncStartDate: Date,
-    page?: number,
+    page?: string,
     metadata?: SyncMetadata
   ): Promise<IGetProofDataResponse | IProofFile[]> {
     throw new Error('getProofData must be implemented by derived class.');

--- a/src/hypersync/RestDataSource.ts
+++ b/src/hypersync/RestDataSource.ts
@@ -1,18 +1,18 @@
-import { ApiClient, compareValues, Logger } from '../common';
 import jsonata from 'jsonata';
 import { HeadersInit } from 'node-fetch';
 import queryString from 'query-string';
+import { ApiClient, compareValues, Logger } from '../common';
 import { StringMap } from './common';
-import { DataObject, DataValue } from './models';
+import { DataSetResultStatus } from './enums';
 import {
   DataValueMap,
-  IDataSource,
   IDataSetResultComplete,
-  IDataSetResultPending
+  IDataSetResultPending,
+  IDataSource
 } from './IDataSource';
-import { resolveTokens, TokenContext } from './tokens';
+import { DataObject, DataValue } from './models';
 import { SyncMetadata } from './Sync';
-import { DataSetResultStatus } from './enums';
+import { resolveTokens, TokenContext } from './tokens';
 
 const LOOKUP_DEFAULT_VALUE = '__default__';
 
@@ -121,6 +121,7 @@ export class RestDataSource extends ApiClient implements IDataSource {
   public async getData<TData>(
     dataSetName: string,
     params?: DataValueMap,
+    page?: string,
     metadata?: SyncMetadata
   ): Promise<RestDataSetResult<TData>> {
     await Logger.debug(
@@ -148,6 +149,7 @@ export class RestDataSource extends ApiClient implements IDataSource {
       dataSet,
       relativeUrl,
       params,
+      page,
       metadata
     );
     if (response.status !== DataSetResultStatus.Complete) {
@@ -279,6 +281,8 @@ export class RestDataSource extends ApiClient implements IDataSource {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     params?: DataValueMap,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    page?: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     metadata?: SyncMetadata
   ): Promise<RestDataSetResult<any>> {
     const { json: data, apiUrl, headers } = await super.getJson(relativeUrl);
@@ -389,6 +393,7 @@ export class RestDataSource extends ApiClient implements IDataSource {
         const response = await this.getData<any>(
           lookup.dataSet,
           params,
+          undefined,
           metadata
         );
         if (response.status !== DataSetResultStatus.Complete) {

--- a/src/hypersync/RestDataSource.ts
+++ b/src/hypersync/RestDataSource.ts
@@ -115,7 +115,7 @@ export class RestDataSource extends ApiClient implements IDataSource {
    *
    * @param {string} dataSetName Name of the data set to retrieve.
    * @param {object} params Parameter values to be used when retrieving data. Optional.
-   * @param {boolean} allowDelay Controls whether pending results are allowed. Optional.
+   * @param {string} page The page value to continue fetching data from a previous sync. Optional.
    * @param {object} metadata Metadata from previous sync run if requeued. Optional.
    */
   public async getData<TData>(
@@ -270,6 +270,7 @@ export class RestDataSource extends ApiClient implements IDataSource {
    * @param {object} dataSet Data set for which data is being retrieved.
    * @param {string} relativeUrl Service-relative URL from which data should be retrieved.
    * @param {object} params Parameter values to be used when retrieving data.  Optional.
+   * @param {string} page The page value to continue fetching data from a previous sync. Optional.
    * @param {object} metadata Metadata from previous sync run if requeued. Optional.
    *
    * @returns RestDataSetResult
@@ -393,7 +394,7 @@ export class RestDataSource extends ApiClient implements IDataSource {
         const response = await this.getData<any>(
           lookup.dataSet,
           params,
-          undefined,
+          undefined, // Paging is not supported for lookups
           metadata
         );
         if (response.status !== DataSetResultStatus.Complete) {

--- a/src/hypersync/hypersyncConnector.ts
+++ b/src/hypersync/hypersyncConnector.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { FusebitContext, StorageItem } from '@fusebit/add-on-sdk';
-import { UserContext, OAuthConnector } from '@fusebit/oauth-connector';
+import { OAuthConnector, UserContext } from '@fusebit/oauth-connector';
+import * as express from 'express';
+import fs from 'fs';
+import createHttpError from 'http-errors';
+import { StatusCodes } from 'http-status-codes';
 import {
   AuthorizationType,
   createConnector,
@@ -19,10 +23,6 @@ import {
   mapObjectTypesParamToType,
   ObjectType
 } from '../common';
-import * as express from 'express';
-import fs from 'fs';
-import createHttpError from 'http-errors';
-import { StatusCodes } from 'http-status-codes';
 import { formatHypersyncError } from './common';
 import { HypersyncStage } from './enums';
 import { createHypersyncStorageClient } from './HypersyncStorageClient';
@@ -504,7 +504,7 @@ export function createHypersync(superclass: typeof OAuthConnector) {
       hypersync: IHypersync,
       syncStartDate: string,
       hyperproofUser: IHyperproofUser,
-      page: number,
+      page?: string,
       metadata?: SyncMetadata
     ): Promise<IGetProofDataResponse | IRetryResponse> {
       throw Error('Not implemented');


### PR DESCRIPTION
It is currently impossible for declarative apps to return a `nextPage` property, so they are always forced to try to get all the data in one HTTP call. This change allows `getDataFromUrl` to be overriden and return a `nextPage` property to support this workflow. 

Supports #3 