### PR TITLE
Remove Generic from IDataSource.getData()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/hypersync-sdk",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "Hypersync SDK",
   "repository": {
     "type": "git",

--- a/src/hypersync/IDataSource.ts
+++ b/src/hypersync/IDataSource.ts
@@ -7,7 +7,7 @@ import { TokenContext } from './tokens';
 export type DataValueMap = { [name: string]: DataValue };
 
 // Result returned from IDataSource's getData method.
-export interface IDataSetResultComplete<TData = DataObject> {
+export interface IDataSetResultComplete<TData> {
   status: DataSetResultStatus.Complete;
   data: TData;
   apiUrl: string;
@@ -41,10 +41,10 @@ export interface IDataSource {
    * @param {object} metadata Metadata from previous sync run if requeued. Only returned
    *  from the previous sync if the status was Pending. Optional.
    */
-  getData<TData = DataObject>(
+  getData(
     dataSetName: string,
     params?: DataValueMap,
     page?: string,
     metadata?: SyncMetadata
-  ): Promise<DataSetResult<TData>>;
+  ): Promise<DataSetResult<DataObject | DataObject[]>>;
 }


### PR DESCRIPTION
Implementations of `IDataSource` aren't able to return inferred type data results, unless the implemented method returns `Promise<DataSetResult<any>>`.

```typescript
class TestDataSource implements IDataSource {
  async getData<TData = DataObject>(
    dataSetName: string,
    params?: DataValueMap,
    page?: string,
    metadata?: SyncMetadata
  ): Promise<DataSetResult<TData>> {
    const data = { any: 'object' };

    return {
      status: DataSetResultStatus.Complete,
      apiUrl: 'http://test.com',
      data: { any: 'object' }
      /*
       * error TS2322: Type '{ any: string; }' is not assignable to type 'TData'.
       * 'TData' could be instantiated with an arbitrary type which could be unrelated to '{ any: string; }'.
       */
    };
  }
}
```

This change fixes this by removing the generic from `IDataSetResult` allowing inferred type data results and leaves generics open to the implementor.