### PR TITLE
Delete schema ref from proof providers before enumerating (XS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/hypersync-sdk",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "description": "Hypersync SDK",
   "repository": {
     "type": "git",

--- a/src/hypersync/ProofProviderFactory.ts
+++ b/src/hypersync/ProofProviderFactory.ts
@@ -50,6 +50,8 @@ export class ProofProviderFactory {
     );
     if (fs.existsSync(proofProvidersPath)) {
       this.providers = JSON.parse(fs.readFileSync(proofProvidersPath, 'utf8'));
+      // If a JSON schema ref was provided, remove it from map.
+      delete this.providers['$schema'];
     } else {
       this.providers = {};
     }


### PR DESCRIPTION
The ProofProviderFactory enumerates the keys in `proofProvider.json` to figure out what proof providers there are.  When I added the `$schema` ref that broke this code because $schema is a meta property and not a proof provider.

The other JSON file types don't have this problem because of the way they are read.

This supports issue #3.