### PR TITLE
Properly implement proof type override spec and make webPageUrl optional.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/hypersync-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Hypersync SDK",
   "repository": {
     "type": "git",

--- a/schema/examples/proofTypeExample.json
+++ b/schema/examples/proofTypeExample.json
@@ -42,5 +42,16 @@
       }
     ],
     "webPageUrl": "https://myservice.com/users"
-  }
+  },
+  "overrides": [
+    {
+      "condition": {
+        "value": "{{criteria.name}}",
+        "criteria": "all_employees"
+      },
+      "proofSpec": {
+        "suggestedName": "All Employees"
+      }
+    }
+  ]
 }

--- a/schema/proofType.schema.json
+++ b/schema/proofType.schema.json
@@ -33,30 +33,34 @@
     "overrides": {
       "type": "array",
       "items": {
-        "condition": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "value": {
-              "type": "string"
-            },
-            "criteria": {
-              "type": "string"
+        "type": "object",
+        "properties": {
+          "condition": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "criteria": {
+                "type": "string"
+              }
             }
+          },
+          "proofSpec": {
+            "$ref": "#/$defs/overrideSpec"
           }
         },
-        "proofSpec": {
-          "$refs": "#/$defs/proofSpec"
-        }
+        "additionalProperties": false
       }
     }
   },
   "required": ["description", "criteria", "proofSpec"],
 
   "$defs": {
-    "proofSpec": {
+    "overrideSpec": {
       "$schema": "https://json-schema.org/draft/2020-12/schema#",
-      "$id": "/schemas/proofSpec",
+      "$id": "/schemas/overrideSpec",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -138,7 +142,10 @@
         "webPageUrl": {
           "type": "string"
         }
-      },
+      }
+    },
+    "proofSpec": {
+      "$ref": "#/$defs/overrideSpec",
       "required": [
         "period",
         "useVersioning",

--- a/schema/proofType.schema.json
+++ b/schema/proofType.schema.json
@@ -155,8 +155,7 @@
         "title",
         "subtitle",
         "dataSet",
-        "fields",
-        "webPageUrl"
+        "fields"
       ]
     }
   }

--- a/schema/proofType.schema.json
+++ b/schema/proofType.schema.json
@@ -34,6 +34,7 @@
       "type": "array",
       "items": {
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "condition": {
             "type": "object",
@@ -50,8 +51,7 @@
           "proofSpec": {
             "$ref": "#/$defs/overrideSpec"
           }
-        },
-        "additionalProperties": false
+        }
       }
     }
   },
@@ -145,6 +145,7 @@
       }
     },
     "proofSpec": {
+      "$id": "/schemas/proofSpec",
       "$ref": "#/$defs/overrideSpec",
       "required": [
         "period",

--- a/src/hypersync/JsonProofProvider.ts
+++ b/src/hypersync/JsonProofProvider.ts
@@ -54,7 +54,7 @@ export interface IProofSpec {
   noResultsMessage?: string;
   lookups?: ILookup[];
   fields: IHypersyncField[];
-  webPageUrl: string;
+  webPageUrl?: string;
 }
 
 export interface IProofSpecOverride {
@@ -251,7 +251,9 @@ export class JsonProofProvider extends ProofProviderBase {
             title: resolveTokens(proofSpec.title, tokenContext),
             subtitle: resolveTokens(proofSpec.subtitle, tokenContext),
             source: source,
-            webPageUrl: resolveTokens(proofSpec.webPageUrl, tokenContext),
+            webPageUrl: proofSpec.webPageUrl
+              ? resolveTokens(proofSpec.webPageUrl, tokenContext)
+              : '',
             orientation: proofSpec.orientation,
             userTimeZone: hyperproofUser.timeZone,
             criteria,

--- a/src/hypersync/JsonProofProvider.ts
+++ b/src/hypersync/JsonProofProvider.ts
@@ -62,7 +62,7 @@ export interface IProofSpecOverride {
     value: string;
     criteria: string;
   };
-  proofSpec: IProofSpec;
+  proofSpec: Partial<IProofSpec>;
 }
 
 export interface IHypersyncDefinition {


### PR DESCRIPTION
The properties on the override object of a proof type were supposed to be optional.  This updates the type as well as the schema to allow for optional properties.

In this change I am also making webPageUrl optional.