### PR TITLE
HYP-43133: add schemaCategory as an optional property to proofTypes schema (XS)

### DIFF
--- a/schema/proofTypes.schema.json
+++ b/schema/proofTypes.schema.json
@@ -7,6 +7,10 @@
   "properties": {
     "$schema": {
       "type": "string"
+    },
+    "schemaCategory": {
+      "type": "string",
+      "enum": ["uarDirectory", "uarApplication"]
     }
   },
   "patternProperties": {


### PR DESCRIPTION
This adds `schemaCategory` as an optional property to proofTypes schema.

relevant PR that's been merged: https://github.com/Hyperproof/integrations/pull/1470