### PR TITLE
Re-export elements from critical dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/hypersync-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Hypersync SDK",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,9 @@
+export * from '@hyperproof/hypersync-models';
+
+export {
+  CredentialFieldType,
+  CustomAuthCredentials,
+  Logger
+} from '@hyperproof/integration-sdk';
+
 export * from './hypersync';


### PR DESCRIPTION
This change should allow SDK developers to only need a dependency to `@hyperproof/hypersync-sdk`