### PR TITLE
Add `delaySeconds` property to `lookups` schema

### DIFF
--- a/schema/restDataSource.schema.json
+++ b/schema/restDataSource.schema.json
@@ -270,6 +270,11 @@
                         ]
                       }
                     }
+                  },
+                  "delaySeconds": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "maximum": 1
                   }
                 },
                 "required": ["alias", "dataSet"]


### PR DESCRIPTION
This supports issue https://github.com/Hyperproof/hypersync-sdk/issues/3