### PR TITLE
Update instructions regarding development and sandbox organizations.

### DIFF
--- a/doc/001-getting-started.md
+++ b/doc/001-getting-started.md
@@ -26,13 +26,14 @@ Finally, we recommend cloning the [Hypersync SDK Samples GitHub repository](http
 
 - The samples repository also includes a handful of templates to get you started building your own Hypersyncs from scatch. Templates can be found in the `/templates` directory. See the `README.md` files in each template directory for more information on using the templates.
 
-## Development Organization
+## Sandbox Organization (optional)
 
-For development purposes you will want to create a separate development organization in Hyperproof. This will allow you to to develop and test your custom Hypersync apps in isolation without affecting the users in your production Hyperproof organization. To create a development organization, contact Hyperproof Customer Support at <support@hyperproof.io>.
+For development purposes it is recommended to have a separate 'sandbox' organization in Hyperproof. This will allow you to develop and test your custom Hypersync apps in isolation without affecting the users in your production Hyperproof organization. To create a 'sandbox' organization, please contact your Hyperproof Customer Service Manager.
+
 
 ## Next Steps
 
-Once you have installed the prerequisites and obtained a development organization, you are ready to install your first custom Hypersync app. Follow the guidance in [App Development Workflow](./002-dev-workflow.md) to install, test and update one of the pre-built sample apps.
+Once you have installed the prerequisites and determined the organization that you will use for development, you are ready to install your first custom Hypersync app. Follow the guidance in [App Development Workflow](./002-dev-workflow.md) to install, test and update one of the pre-built sample apps.
 
 <br></br>
 [Return to Table of Contents](./000-toc.md)

--- a/doc/002-dev-workflow.md
+++ b/doc/002-dev-workflow.md
@@ -18,7 +18,9 @@ hp signin
 
 This command will launch a new browser window and allow you to sign in (if you are not already signed in) and then authorize CLI access to your Hyperproof organization.
 
-> NOTE: If you are a member of more than one organization, you will be asked to choose the organization on the authorization screen. Make sure you choose your development organization.
+> NOTE: If you are a member of more than one organization, you will be asked to choose the organization on the authorization screen.
+
+> NOTE: Make sure you choose your 'sandbox' organization if you have one available.
 
 ### Importing Your Hypersync App
 
@@ -57,7 +59,7 @@ The import might take a minute or two to complete. Once it is done, you are read
 
 ### Using a Your Hypersync App
 
-1. In the browser, navigate to <https://hyperproof.io> and sign into your development organization.
+1. In the browser, navigate to <https://hyperproof.io> and sign into the organization that you will use for development.
 2. Navigate to any Control or Label that you have permissions to access.
 3. Click on the **Automations** tab.
 4. Click the **+New Hypersync** button.


### PR DESCRIPTION
-Removed and replaced references to 'development organization' to be more generic wording about sandbox orgs.

-Updated instructions to contact CSM for a sandbox org instead of support. (per discussions with support and Derik Stenerson)
