### PR TITLE
Documentation update with UAR instructions

### DIFF
--- a/doc/030-package-json-reference.md
+++ b/doc/030-package-json-reference.md
@@ -2,7 +2,7 @@
 
 Every custom Hypersync app must have a `package.json` file that contains certain properties. Hyperproof uses these property values to properly identify and display your custom Hypersync app in the Hyperproof user interface.
 
-The `package.json` file for a custom Hypersync app must contain the values shown below:
+The `package.json` file for a custom Hypersync app must contain the values shown below.:
 
 ```
 {
@@ -15,11 +15,17 @@ The `package.json` file for a custom Hypersync app must contain the values shown
         "category": "Identity Services",
         "descriptionCapabilities": "This integration extracts user and group information from The Target Service.",
         "debug": true,
-        "staticIp": false
+        "staticIp": false,
+        "schemaCategories": [
+          "uarApplication", "uarDirectory"
+        ]
     },
     ...
 }
 ```
+NOTE: `schemaCategories` array is optional and only required for Hypersyncs that need to utilize the Access Review module.
+
+NOTE: When attempting to upgrade existing Hypersyncs to the `schemaCategories` for Access Review proofs, you must first delete the existing Hypersync using the CLI command `hp customapps delete`. This ensures that the new `schemaCategories` definition is added to your Hypersync.   
 
 ## name
 
@@ -42,7 +48,7 @@ More information on the version attribute can be found [here](https://docs.npmjs
 The `app_hyperproof` value in `package.json` is an object that contains values that Hyperproof uses to properly expose and run your custom Hypersync app. The object must contain the values in the table below.
 
 | Attribute               | Description                                                                                                                                                                                                                                                                              |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ----------------------- |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | name                    | The name of your application as shown in the Hyperproof UI.                                                                                                                                                                                                                              |
 | appType                 | The type of custom app. Must be set to `hypersync`.                                                                                                                                                                                                                                      |
 | authType                | The type of authentication/authorization used by your application. Acceptable values are `custom` or `oauth`.                                                                                                                                                                            |
@@ -50,3 +56,4 @@ The `app_hyperproof` value in `package.json` is an object that contains values t
 | descriptionCapabilities | Description shown to the user when inspecting a connection under Connected Accounts.                                                                                                                                                                                                     |
 | debug                   | True to include debug information (e.g. `Logger.debug` output) in the logs.                                                                                                                                                                                                              |
 | staticIp                | Boolean value (true or false) which indicates whether or not a static IP is required. If your target service is on premise or lives behind a firewall setting this to true will allow you to open a port for your custom Hypersync app to talk to the target service. Defaults to false. |
+| schemaCategories        | Optional Array value containing one or both of the UAR categories `uarApplication` or `uarDirectory` for use in Access Review Hypersyncs                                                                                                                                                 |

--- a/doc/030-package-json-reference.md
+++ b/doc/030-package-json-reference.md
@@ -2,7 +2,7 @@
 
 Every custom Hypersync app must have a `package.json` file that contains certain properties. Hyperproof uses these property values to properly identify and display your custom Hypersync app in the Hyperproof user interface.
 
-The `package.json` file for a custom Hypersync app must contain the values shown below.:
+The `package.json` file for a custom Hypersync app must contain the values shown below:
 
 ```
 {
@@ -25,7 +25,7 @@ The `package.json` file for a custom Hypersync app must contain the values shown
 ```
 NOTE: `schemaCategories` array is optional and only required for Hypersyncs that need to utilize the Access Review module.
 
-NOTE: When attempting to upgrade existing Hypersyncs to the `schemaCategories` for Access Review proofs, you must first delete the existing Hypersync using the CLI command `hp customapps delete`. This ensures that the new `schemaCategories` definition is added to your Hypersync.   
+NOTE: When attempting to upgrade existing Hypersyncs to the `schemaCategories` for Access Review proofs, you must first delete the existing Hypersync using the CLI command `hp customapps delete`. This ensures that the new `schemaCategories` definition is added to your Hypersync.
 
 ## name
 

--- a/doc/054-proof-types-json.md
+++ b/doc/054-proof-types-json.md
@@ -12,6 +12,8 @@ If a category is specified, it will be used to match the proof against the proof
 
 The label attribute is the human-readable name of the proof type. It is shown to the user in the Proof Type field.
 
+An additional optional property 'schemaCategory' is required if the Hypersync is to be used in the 'Access Reviews' module.
+
 ## Example
 
 ```
@@ -28,6 +30,10 @@ The label attribute is the human-readable name of the proof type. It is shown to
     "deviceList": {
         "label": "{{messages.PROOF_TYPE_DEVICE_LIST}}",
         "category": "devices"
-    }
+    },
+    "listOfUsersApplication": {
+        "label": "{{messages.PROOF_TYPE_USER_LIST}}",
+        "schemaCategory": "uarApplication"
+    }   
 }
 ```

--- a/doc/hyperproof-cli.md
+++ b/doc/hyperproof-cli.md
@@ -11,9 +11,9 @@ The Hyperproof CLI is a cross-platform command line tool that can be installed t
 - [Linux (Ubuntu)](#install-on-linux)
 - [Windows 10 and 11](#install-on-windows)
 
-The Hyperproof CLI has a dependency on the .Net Runtime 7.0. Before installing the Hyperproof CLI, please install the .Net Runtime 7.0 using the link below.
+The Hyperproof CLI has a dependency on the .Net Runtime 8.0. Before installing the Hyperproof CLI, please install the .Net Runtime 8.0 using the link below.
 
-- [Download .Net 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0).
+- [Download .Net 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).
 
 ### Install on Linux
 
@@ -25,9 +25,9 @@ The Hyperproof CLI has been tested on the following Linux distributions.
 
 It may also be installed on other Debian distributions but the Hyperprof CLI has not been tested on these platforms.
 
-Once you have installed the [.Net Runtime 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0), the CLI can be installed by downloading a `.deb` package from the Hyperproof web site. Click the link below to download the latest version of the Hyperproof CLI.
+Once you have installed the [.Net Runtime 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0), the CLI can be installed by downloading a `.deb` package from the Hyperproof web site. Click the link below to download the latest version of the Hyperproof CLI.
 
-- [Download HP CLI `.deb` for Debian Linux Distributions](https://downloads.hyperproof.app/hpcli/hpcli_1.1.1-1_amd64.deb)
+- [Download HP CLI `.deb` for Debian Linux Distributions](https://downloads.hyperproof.app/hpcli/hpcli_1.2.2-1_amd64.deb)
 
 The `.deb` package installs the HP CLI under `/usr/bin`.
 
@@ -42,15 +42,15 @@ The Hyperproof CLI has been tested on the following Windows versions.
 | Windows 10 |
 | Windows 11 |
 
-Once you have installed the [.Net Runtime 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0), click the link below to download and run the HP CLI Windows installer.
+Once you have installed the [.Net Runtime 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0), click the link below to download and run the HP CLI Windows installer.
 
-- [Download HP CLI Windows Installer](https://downloads.hyperproof.app/hpcli/hpcli-1.1.1.exe)
+- [Download HP CLI Windows Installer](https://downloads.hyperproof.app/hpcli/hpcli-1.2.2.exe)
 
 The Hyperproof CLI will be installed under `C:\Program Files\Hyperproof CLI` unless you choose a different installation location. The installation directory should be added to your path.
 
 ### Install on Mac
 
-The Hyperproof CLI for Mac depends on the [.Net Runtime 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0). Use the links on that page to install the appropriate .Net 7.0 Runtime for your system.
+The Hyperproof CLI for Mac depends on the [.Net Runtime 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0). Use the links on that page to install the appropriate .Net 8.0 Runtime for your system.
 
 Once you have installed the .Net Runtime, you can use Homebrew to install, update and uninstall the Hyperproof CLI. If you don't have Homebrew available on your system, install [Homebrew](https://docs.brew.sh/Installation.html) before continuing.
 


### PR DESCRIPTION
Updated doc to include instruction for making UAR Hypersyncs.

Added a 'Note' to 030-package-json-reference.md regarding deleteing existing customapps when upgrading to UAR.
This essentially documents the workaround to bug HYP-59624. Once this bug is fixed, this Note should be removed.